### PR TITLE
Fixing merge bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 .env.test.local
 .env.production.local
 .env.development
+.env.production
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/assorted/hooks/uiLanguageHook.js
+++ b/src/assorted/hooks/uiLanguageHook.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import uiLanguages from "../uiLanguages";
+import { defaultUILanguage } from "../uiLanguages";
 import LocalStorage from "../LocalStorage";
 import strings from "../../i18n/definitions";
 
@@ -8,13 +8,11 @@ import strings from "../../i18n/definitions";
 // the useEffect initializes the UI language with a default 'en'
 
 export default function useUILanguage() {
-  let defaultUILanguage = uiLanguages[1];
-  if (LocalStorage.getUiLanguage() !== undefined) {
-    defaultUILanguage = LocalStorage.getUiLanguage();
-  } else {
-    LocalStorage.setUiLanguage(uiLanguages[1]);
+  if (LocalStorage.getUiLanguage() === undefined) {
+    LocalStorage.setUiLanguage(defaultUILanguage);
   }
-  const [uiLanguage, setUiLanguage] = useState(defaultUILanguage);
+
+  const [uiLanguage, setUiLanguage] = useState(LocalStorage.getUiLanguage());
 
   useEffect(() => {
     strings.setLanguage(uiLanguage.code);

--- a/src/assorted/hooks/uiLanguageHook.js
+++ b/src/assorted/hooks/uiLanguageHook.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import uiLanguages from "../uiLanguages";
 import LocalStorage from "../LocalStorage";
 import strings from "../../i18n/definitions";
 
@@ -7,9 +8,11 @@ import strings from "../../i18n/definitions";
 // the useEffect initializes the UI language with a default 'en'
 
 export default function useUILanguage() {
-  let defaultUILanguage = { code: "en" };
+  let defaultUILanguage = uiLanguages[1];
   if (LocalStorage.getUiLanguage() !== undefined) {
     defaultUILanguage = LocalStorage.getUiLanguage();
+  } else {
+    LocalStorage.setUiLanguage(uiLanguages[1]);
   }
   const [uiLanguage, setUiLanguage] = useState(defaultUILanguage);
 

--- a/src/assorted/uiLanguages.js
+++ b/src/assorted/uiLanguages.js
@@ -1,4 +1,4 @@
-export default [
+const uiLanguages = [
   {
     name: "Danish",
     code: "da",
@@ -12,3 +12,7 @@ export default [
     deselectedIcon: "/static/icons/eng-deselected.png",
   },
 ];
+
+const defaultUILanguage = uiLanguages[1];
+
+export { uiLanguages as default, defaultUILanguage };

--- a/src/components/UiLanguageSelector.js
+++ b/src/components/UiLanguageSelector.js
@@ -4,7 +4,7 @@ export default function UiLanguageSelector({ languages, selected, onChange }) {
   return (
     <select
       name="learned_language"
-      value={selected}
+      value={strings[selected.toLowerCase()]}
       onChange={(e) => onChange(e)}
     >
       {languages.map((lang) => (

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -111,8 +111,6 @@ export default function Settings({ api, setUser }) {
     return <LoadingAnimation />;
   }
 
-  console.log(uiLanguages);
-
   return (
     <s.FormContainer>
       <form className="formSettings">
@@ -149,13 +147,7 @@ export default function Settings({ api, setUser }) {
             languages.learnable_languages
           )}
           onChange={(e) => {
-            console.log("e");
             let code = e.target[e.target.selectedIndex].getAttribute("code");
-            console.log(code);
-            console.log({
-              ...userDetails,
-              learned_language: code,
-            });
             setUserDetails({
               ...userDetails,
               learned_language: code,

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -7,6 +7,8 @@ import * as s from "../components/FormPage.sc";
 import LocalStorage from "../assorted/LocalStorage";
 
 export default function SignIn({ api, notifySuccessfulSignIn }) {
+  // TODO: Fix this bug in a different way. Requires understanding why strings._language changes to "da" without it being asked to, whenever this component renders. Perhaps it imports an un-updated version of strings?
+  strings.setLanguage(LocalStorage.getUiLanguage().code)
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");


### PR DESCRIPTION
@mircealungu 
Please test this on your system.

Apparantly SignIn and strings are magic when combined, because using strings.setLanguage in a useEffect did nothing, but calling the same in the root of the component works. Ended up doing the latter, which is brutish, but I am out of ideas as to why strings._language changes to "da" whenever SignIn renders.
I figured it'd be fine since SignIn is not a component rendered in any complex tree, but alone and only once in a while.