### PR TITLE
reader buttons stick to the top of the screen

### DIFF
--- a/src/reader/ArticleReader.sc.js
+++ b/src/reader/ArticleReader.sc.js
@@ -19,11 +19,8 @@ let ArticleReader = styled.div`
 
 let Toolbar = styled.div`
   /* border: 1px solid wheat; */
-  position: sticky;
   background-color: white;
-  right: 1em;
   height: 110px;
-  top: -10px;
 
   display: flexbox;
   flex-direction: row;
@@ -159,6 +156,12 @@ let ExtraSpaceAtTheBottom = styled.div`
   margin-bottom: 8em;
 `;
 
+let StickyButton = styled.button`
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+`;
+
 export {
   ArticleReader,
   Toolbar,
@@ -172,4 +175,5 @@ export {
   ExtraSpaceAtTheBottom,
   NarrowColumn,
   ContentOnRow,
+  StickyButton,
 };

--- a/src/teacher/TeacherButtons.sc.js
+++ b/src/teacher/TeacherButtons.sc.js
@@ -119,6 +119,9 @@ const PopupButtonWrapper = styled.div`
   margin-top: 25px;
   display: flex;
   justify-content: flex-end;
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
 `;
 
 export { StyledButton, TopButtonWrapper, PopupButtonWrapper };


### PR DESCRIPTION
First! :-)

closes #82 

Unfortunately there is that whitespace below the buttons for the tooltips that don't look super great. Let me know if I should look into removing it or if it's ok.