### PR TITLE
Fix small non-scrollable top-button issues

### DIFF
--- a/src/components/SideBar.sc.js
+++ b/src/components/SideBar.sc.js
@@ -15,7 +15,9 @@ let mainPageContentCommon = css`
   top: 0;
   overflow-y: scroll;
   height: 100vh;
-  padding: 6px;
+  padding-bottom: 6px;
+  padding-left: 6px;
+  padding-right: 6px;
   overflow-x: hidden;
 `;
 

--- a/src/reader/ArticleReader.sc.js
+++ b/src/reader/ArticleReader.sc.js
@@ -161,12 +161,6 @@ let ExtraSpaceAtTheBottom = styled.div`
   margin-bottom: 8em;
 `;
 
-let StickyButton = styled.button`
-  position: -webkit-sticky;
-  position: sticky;
-  top: 0;
-`;
-
 export {
   ArticleReader,
   Toolbar,
@@ -180,5 +174,4 @@ export {
   ExtraSpaceAtTheBottom,
   NarrowColumn,
   ContentOnRow,
-  StickyButton,
 };

--- a/src/teacher/TeacherButtons.sc.js
+++ b/src/teacher/TeacherButtons.sc.js
@@ -121,7 +121,7 @@ const PopupButtonWrapper = styled.div`
   justify-content: flex-end;
   position: sticky;
   position: -webkit-sticky;
-  top: -10px;
+  top: 0;
   background: white;
   border-bottom: 1px solid #f8f8f0;
 `;

--- a/src/teacher/TeacherButtons.sc.js
+++ b/src/teacher/TeacherButtons.sc.js
@@ -124,7 +124,6 @@ const PopupButtonWrapper = styled.div`
   top: -10px;
   background: white;
   border-bottom: 1px solid #f8f8f0;
-}
 `;
 
 export { StyledButton, TopButtonWrapper, PopupButtonWrapper };

--- a/src/words/WordsForArticle.js
+++ b/src/words/WordsForArticle.js
@@ -6,10 +6,17 @@ import Word from "./Word";
 
 import { TopMessage } from "../components/TopMessage.sc";
 import { NarrowColumn, CenteredContent } from "../components/ColumnWidth.sc";
-import { OrangeButton, WhiteButton } from "../reader/ArticleReader.sc";
+import {
+  OrangeButton,
+  WhiteButton,
+  ContentOnRow,
+} from "../reader/ArticleReader.sc";
 import { setTitle } from "../assorted/setTitle";
+import SpeakButton from "../exercises/exerciseTypes/SpeakButton";
 
 export default function WordsForArticle({ api }) {
+  const small = "small";
+
   let { articleID } = useParams();
   const [words, setWords] = useState(null);
   const [articleInfo, setArticleInfo] = useState(null);
@@ -66,12 +73,20 @@ export default function WordsForArticle({ api }) {
       </TopMessage>
 
       {words.map((each) => (
-        <Word
-          key={each.id}
-          bookmark={each}
-          notifyDelete={deleteBookmark}
-          api={api}
-        />
+        <ContentOnRow>
+          <Word
+            key={each.id}
+            bookmark={each}
+            notifyDelete={deleteBookmark}
+            api={api}
+          />
+          <SpeakButton
+            key={each.id}
+            bookmarkToStudy={each}
+            api={api}
+            styling={small}
+          />
+        </ContentOnRow>
       ))}
 
       <br />


### PR DESCRIPTION
There was an error in `PopupButtonWrapper` and `StickyButton` was something I mistakenly committed last time (first attempted fix when trying to have the buttons stick to the top).

I've also discovered why the -10px were needed. Actually, only -6px were really needed. I've kept `top: 0;` by removing the padding of 6px from the top in `mainPageContentCommon`.

close #92 