### PR TITLE
Add InteractiveText + fix tooltip size + minor fix

### DIFF
--- a/src/exercises/bottomActions/FeedbackButtons.js
+++ b/src/exercises/bottomActions/FeedbackButtons.js
@@ -142,7 +142,11 @@ export default function FeedbackButtons({
       )}
       {show && (
         <s.FeedbackButtonsHolder>
-          <Tooltip title={strings.dislikeTooltip}>
+          <Tooltip
+            title={
+              <p style={{ fontSize: "small" }}>{strings.dislikeTooltip}</p>
+            }
+          >
             <s.FeedbackButton
               key="dislike"
               onClick={() => buttonClick(THUMBS_DOWN_VALUE)}
@@ -156,7 +160,9 @@ export default function FeedbackButtons({
           </Tooltip>
           {buttons.map((each) =>
             each.value === "other" ? (
-              <Tooltip title={each.tooltip}>
+              <Tooltip
+                title={<p style={{ fontSize: "small" }}>{each.tooltip}</p>}
+              >
                 <s.FeedbackButton
                   key={each.value}
                   className={className}
@@ -166,7 +172,9 @@ export default function FeedbackButtons({
                 </s.FeedbackButton>
               </Tooltip>
             ) : (
-              <Tooltip title={each.tooltip}>
+              <Tooltip
+                title={<p style={{ fontSize: "small" }}>{each.tooltip}</p>}
+              >
                 <s.FeedbackButton
                   key={each.value}
                   onClick={() => buttonClick(each.value)}

--- a/src/exercises/exerciseTypes/match/MatchInput.js
+++ b/src/exercises/exerciseTypes/match/MatchInput.js
@@ -109,6 +109,7 @@ function MatchInput({
                       bookmarkToStudy={option}
                       api={api}
                       styling={small}
+                      key={"L2_Speak_" + option.id}
                     />
                   </s.MatchSpeakButtonHolder>
                 </s.ButtonRow>

--- a/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
+++ b/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
@@ -39,14 +39,7 @@ export default function MultipleChoice({
     });
     api.getArticleInfo(bookmarksToStudy[0].article_id, (articleInfo) => {
       setInteractiveText(
-        new InteractiveText(
-          contextWithMissingWord(
-            bookmarksToStudy[0].context,
-            bookmarksToStudy[0].from
-          ),
-          articleInfo,
-          api
-        )
+        new InteractiveText(bookmarksToStudy[0].context, articleInfo, api)
       );
       setArticleInfo(articleInfo);
     });
@@ -103,10 +96,6 @@ export default function MultipleChoice({
     );
   }
 
-  function contextWithMissingWord(context, missingWord) {
-    return context.replace(missingWord, "______");
-  }
-
   function consolidateChoiceOptions(similarWords) {
     let firstRandomInt = Math.floor(Math.random() * similarWords.length);
     let secondRandomInt;
@@ -148,6 +137,7 @@ export default function MultipleChoice({
           interactiveText={interactiveText}
           translating={true}
           pronouncing={false}
+          bookmarkToStudy={bookmarksToStudy[0].from}
         />
       )}
 

--- a/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
+++ b/src/exercises/exerciseTypes/multipleChoice/MultipleChoice.js
@@ -3,6 +3,8 @@ import * as s from "../Exercise.sc.js";
 import MultipleChoicesInput from "./MultipleChoicesInput.js";
 import SolutionFeedbackLinks from "../SolutionFeedbackLinks.js";
 import LoadingAnimation from "../../../components/LoadingAnimation";
+import InteractiveText from "../../../reader/InteractiveText.js";
+import { TranslatableText } from "../../../reader/TranslatableText.js";
 
 import NextNavigation from "../NextNavigation";
 import strings from "../../../i18n/definitions.js";
@@ -27,11 +29,26 @@ export default function MultipleChoice({
   const [initialTime] = useState(new Date());
   const [buttonOptions, setButtonOptions] = useState(null);
   const [messageToAPI, setMessageToAPI] = useState("");
+  const [articleInfo, setArticleInfo] = useState();
+  const [interactiveText, setInteractiveText] = useState();
 
   useEffect(() => {
     setExerciseType(EXERCISE_TYPE);
     api.wordsSimilarTo(bookmarksToStudy[0].id, (words) => {
       consolidateChoiceOptions(words);
+    });
+    api.getArticleInfo(bookmarksToStudy[0].article_id, (articleInfo) => {
+      setInteractiveText(
+        new InteractiveText(
+          contextWithMissingWord(
+            bookmarksToStudy[0].context,
+            bookmarksToStudy[0].from
+          ),
+          articleInfo,
+          api
+        )
+      );
+      setArticleInfo(articleInfo);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -105,27 +122,34 @@ export default function MultipleChoice({
     setButtonOptions(shuffledListOfOptions);
   }
 
+  if (!articleInfo) {
+    return <LoadingAnimation />;
+  }
+
   return (
     <s.Exercise>
       <div className="headlineWithMoreSpace">
         {strings.chooseTheWordFittingContextHeadline}{" "}
       </div>
 
-      <div className="contextExample">
-        <div
-          dangerouslySetInnerHTML={{
-            __html: isCorrect
-              ? colorWordInContext(
-                  bookmarksToStudy[0].context,
-                  bookmarksToStudy[0].from
-                )
-              : contextWithMissingWord(
-                  bookmarksToStudy[0].context,
-                  bookmarksToStudy[0].from
-                ),
-          }}
+      {isCorrect ? (
+        <div className="contextExample">
+          <div
+            dangerouslySetInnerHTML={{
+              __html: colorWordInContext(
+                bookmarksToStudy[0].context,
+                bookmarksToStudy[0].from
+              ),
+            }}
+          />
+        </div>
+      ) : (
+        <TranslatableText
+          interactiveText={interactiveText}
+          translating={true}
+          pronouncing={false}
         />
-      </div>
+      )}
 
       {isCorrect && <h1>{bookmarksToStudy[0].to}</h1>}
 

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -318,8 +318,12 @@ let strings = new LocalizedStrings(
           feels wrong.
           <br />
           <br />
-          NB: You can improve the translation after finding/showing the
-          solution. If you wish to do so, do not click on this feedback button.
+          <strong>NB:</strong> You can improve the translation after
+          finding/showing the solution. If you wish to do so,{" "}
+          <u>
+            <strong>do not</strong>
+          </u>{" "}
+          click on this feedback button.
         </div>
       ),
       badContext: "Bad Context",
@@ -915,9 +919,12 @@ let strings = new LocalizedStrings(
           føles forkert.
           <br />
           <br />
-          OBS: Du kan forbedre oversættelsen efter at have fundet/vist
-          løsningen. Hvis du ønsker at gøre det, skal du ikke klikke på denne
-          feedback-knap.
+          <strong>OBS:</strong> Du kan forbedre oversættelsen efter at have
+          fundet/vist løsningen. Hvis du ønsker at gøre det,{" "}
+          <u>
+            <strong>skal du ikke</strong>
+          </u>{" "}
+          klikke på denne feedback-knap.
         </div>
       ),
       badContext: "Dårlig kontekst",

--- a/src/reader/TranslatableText.js
+++ b/src/reader/TranslatableText.js
@@ -8,6 +8,7 @@ export function TranslatableText({
   pronouncing,
   translatedWords,
   setTranslatedWords,
+  bookmarkToStudy,
 }) {
   const [translationCount, setTranslationCount] = useState(0);
 
@@ -18,18 +19,24 @@ export function TranslatableText({
     <s.TranslatableText>
       {interactiveText.getParagraphs().map((par, index) => (
         <div key={index} className="textParagraph">
-          {par.getWords().map((word) => (
-            <TranslatableWord
-              interactiveText={interactiveText}
-              key={word.id}
-              word={word}
-              wordUpdated={wordUpdated}
-              translating={translating}
-              pronouncing={pronouncing}
-              translatedWords={translatedWords}
-              setTranslatedWords={setTranslatedWords}
-            />
-          ))}
+          {par
+            .getWords()
+            .map((word) =>
+              word.word === bookmarkToStudy ? (
+                "______ "
+              ) : (
+                <TranslatableWord
+                  interactiveText={interactiveText}
+                  key={word.id}
+                  word={word}
+                  wordUpdated={wordUpdated}
+                  translating={translating}
+                  pronouncing={pronouncing}
+                  translatedWords={translatedWords}
+                  setTranslatedWords={setTranslatedWords}
+                />
+              )
+            )}
         </div>
       ))}
     </s.TranslatableText>

--- a/src/reader/TranslatableText.js
+++ b/src/reader/TranslatableText.js
@@ -6,6 +6,8 @@ export function TranslatableText({
   interactiveText,
   translating,
   pronouncing,
+  translatedWords,
+  setTranslatedWords,
 }) {
   const [translationCount, setTranslationCount] = useState(0);
 
@@ -24,6 +26,8 @@ export function TranslatableText({
               wordUpdated={wordUpdated}
               translating={translating}
               pronouncing={pronouncing}
+              translatedWords={translatedWords}
+              setTranslatedWords={setTranslatedWords}
             />
           ))}
         </div>

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -14,11 +14,9 @@ export default function TranslatableWord({
 
   function clickOnWord(word) {
     if (translating) {
-      if (word.word !== "______") {
-        interactiveText.translate(word, () => {
-          wordUpdated();
-        });
-      }
+      interactiveText.translate(word, () => {
+        wordUpdated();
+      });
       if (translatedWords) {
         let copyOfWords = [...translatedWords];
         copyOfWords.push(word.word);

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -7,14 +7,23 @@ export default function TranslatableWord({
   wordUpdated,
   translating,
   pronouncing,
+  translatedWords,
+  setTranslatedWords,
 }) {
   const [showingAlternatives, setShowingAlternatives] = useState(false);
 
   function clickOnWord(word) {
     if (translating) {
-      interactiveText.translate(word, () => {
-        wordUpdated();
-      });
+      if (word.word !== "______") {
+        interactiveText.translate(word, () => {
+          wordUpdated();
+        });
+      }
+      if (translatedWords) {
+        let copyOfWords = [...translatedWords];
+        copyOfWords.push(word.word);
+        setTranslatedWords(copyOfWords);
+      }
     }
     if (pronouncing) {
       interactiveText.pronounce(word);


### PR DESCRIPTION
I've added an `InteractiveText` to both exercise types with contexts. If the student translates any of the words contained in the `bookmarkToStudy`, the answer is flagged as incorrect and the API is notified with a "T" appended to the message in the `FindWordInContext` exercise. In the `MultipleChoice` exercise, the `InteractiveText` is very straightforward - making sure the missing word isn't translatable at all. 

As mentioned in #108, the tooltip size has been adjusted to "small" and some words have been highlighted ("**NB**" & "**do not**" in the first feedback option).

Minor fixes to avoid log complaints are included in this PR. 
Closes #45 and #103.