### PR TITLE
Mircea proposed changes to extensions exercises

### DIFF
--- a/src/exercises/Congratulations.js
+++ b/src/exercises/Congratulations.js
@@ -1,6 +1,5 @@
 import Word from "../words/Word";
 import * as s from "../reader/ArticleReader.sc";
-import { Link } from "react-router-dom";
 import strings from "../i18n/definitions";
 import { useState } from "react";
 
@@ -11,7 +10,6 @@ export default function Congratulations({
   correctBookmarks,
   incorrectBookmarks,
   api,
-  source,
   backToReading,
   keepExercising,
 }) {

--- a/src/exercises/Congratulations.js
+++ b/src/exercises/Congratulations.js
@@ -8,8 +8,8 @@ export default function Congratulations({
   correctBookmarks,
   incorrectBookmarks,
   api,
-  backToReading,
-  keepExercising,
+  backToReadingAction,
+  keepExercisingAction,
 }) {
   const [correctBookmarksToDisplay, setCorrectBookmarksToDisplay] = useState(
     removeArrayDuplicates(correctBookmarks)
@@ -72,10 +72,10 @@ export default function Congratulations({
       )}
 
       <s.ContentOnRow>
-        <s.OrangeButton onClick={keepExercising}>
+        <s.OrangeButton onClick={keepExercisingAction}>
           {strings.keepExercising}
         </s.OrangeButton>
-        <s.WhiteButton onClick={backToReading}>
+        <s.WhiteButton onClick={backToReadingAction}>
           {strings.backToReading}
         </s.WhiteButton>
       </s.ContentOnRow>

--- a/src/exercises/Congratulations.js
+++ b/src/exercises/Congratulations.js
@@ -3,8 +3,6 @@ import * as s from "../reader/ArticleReader.sc";
 import strings from "../i18n/definitions";
 import { useState } from "react";
 
-export const EXTENSION_SOURCE = "EXTENSION";
-
 export default function Congratulations({
   articleID,
   correctBookmarks,

--- a/src/exercises/Congratulations.js
+++ b/src/exercises/Congratulations.js
@@ -12,8 +12,8 @@ export default function Congratulations({
   incorrectBookmarks,
   api,
   source,
-  openArticle,
-  reloadExercises,
+  backToReading,
+  keepExercising,
 }) {
   const [correctBookmarksToDisplay, setCorrectBookmarksToDisplay] = useState(
     removeArrayDuplicates(correctBookmarks)
@@ -76,25 +76,12 @@ export default function Congratulations({
       )}
 
       <s.ContentOnRow>
-        {source === EXTENSION_SOURCE ? (
-          <>
-            <s.OrangeButton onClick={reloadExercises}>{strings.keepExercising}</s.OrangeButton>
-            <s.WhiteButton onClick={openArticle}>{strings.backToReading}</s.WhiteButton>
-          </>
-        ) : (
-          <>
-            <Link
-              to={`/exercises`}
-              onClick={(e) => window.location.reload(false)}
-            >
-              <s.OrangeButton>{strings.keepExercising}</s.OrangeButton>
-            </Link>
-
-            <Link to={`/articles`}>
-              <s.WhiteButton>{strings.backToReading}</s.WhiteButton>
-            </Link>
-          </>
-        )}
+        <s.OrangeButton onClick={keepExercising}>
+          {strings.keepExercising}
+        </s.OrangeButton>
+        <s.WhiteButton onClick={backToReading}>
+          {strings.backToReading}
+        </s.WhiteButton>
       </s.ContentOnRow>
     </s.NarrowColumn>
   );

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -189,8 +189,8 @@ export default function Exercises({
           correctBookmarks={correctBookmarks}
           incorrectBookmarks={incorrectBookmarks}
           api={api}
-          backToReading={() => history.push("/articles")}
-          keepExercising={() => window.location.reload(false)}
+          backToReadingAction={() => history.push("/articles")}
+          keepExercisingAction={() => window.location.reload(false)}
         />
       </div>
     );

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { useHistory } from "react-router-dom";
+
 import FindWordInContext from "./exerciseTypes/findWordInContext/FindWordInContext";
 import MultipleChoice from "./exerciseTypes/multipleChoice/MultipleChoice";
 import Congratulations from "./Congratulations";
@@ -29,7 +31,14 @@ let BOOKMARKS_FOR_EXERCISE = [
   },
 ];
 
-export default function Exercises({ api, articleID, source, openArticle, reloadExercises, openReview}) {
+export default function Exercises({
+  api,
+  articleID,
+  source,
+  openArticle,
+  reloadExercises,
+  openReview,
+}) {
   const [countBookmarksToPractice, setCountBookmarksToPractice] = useState(
     DEFAULT_BOOKMARKS_TO_PRACTICE
   );
@@ -44,6 +53,7 @@ export default function Exercises({ api, articleID, source, openArticle, reloadE
   const [isCorrect, setIsCorrect] = useState(false);
   const [showFeedbackButtons, setShowFeedbackButtons] = useState(false);
   const [reload, setReload] = useState(false);
+  const history = useHistory();
 
   useEffect(() => {
     if (exerciseSession.length === 0) {
@@ -180,8 +190,8 @@ export default function Exercises({ api, articleID, source, openArticle, reloadE
           incorrectBookmarks={incorrectBookmarks}
           api={api}
           source={source}
-          openArticle={openArticle}
-          reloadExercises={reloadExercises}
+          backToReading={() => history.push("/articles")}
+          keepExercising={() => window.location.reload(false)}
         />
       </div>
     );
@@ -194,14 +204,18 @@ export default function Exercises({ api, articleID, source, openArticle, reloadE
   if (countBookmarksToPractice === 0 && !articleID) {
     return (
       <s.ExercisesColumn>
-        <OutOfWordsMessage source={source} openReview={openReview}/>
+        <OutOfWordsMessage source={source} openReview={openReview} />
       </s.ExercisesColumn>
     );
   }
   if (countBookmarksToPractice === 0 && articleID) {
     return (
       <s.ExercisesColumn>
-        <OutOfWordsMessage action={"back"} source={source} openReview={openReview}/>
+        <OutOfWordsMessage
+          action={"back"}
+          source={source}
+          openReview={openReview}
+        />
       </s.ExercisesColumn>
     );
   }

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -183,16 +183,14 @@ export default function Exercises({
 
   if (finished) {
     return (
-      <div>
-        <Congratulations
-          articleID={articleID}
-          correctBookmarks={correctBookmarks}
-          incorrectBookmarks={incorrectBookmarks}
-          api={api}
-          backToReadingAction={() => history.push("/articles")}
-          keepExercisingAction={() => window.location.reload(false)}
-        />
-      </div>
+      <Congratulations
+        articleID={articleID}
+        correctBookmarks={correctBookmarks}
+        incorrectBookmarks={incorrectBookmarks}
+        api={api}
+        backToReadingAction={() => history.push("/articles")}
+        keepExercisingAction={() => window.location.reload(false)}
+      />
     );
   }
 

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -189,7 +189,6 @@ export default function Exercises({
           correctBookmarks={correctBookmarks}
           incorrectBookmarks={incorrectBookmarks}
           api={api}
-          source={source}
           backToReading={() => history.push("/articles")}
           keepExercising={() => window.location.reload(false)}
         />
@@ -201,23 +200,26 @@ export default function Exercises({
     return <LoadingAnimation />;
   }
 
-  if (countBookmarksToPractice === 0 && !articleID) {
-    return (
-      <s.ExercisesColumn>
-        <OutOfWordsMessage source={source} openReview={openReview} />
-      </s.ExercisesColumn>
-    );
-  }
-  if (countBookmarksToPractice === 0 && articleID) {
-    return (
-      <s.ExercisesColumn>
+  if (countBookmarksToPractice === 0) {
+    if (!articleID) {
+      return (
         <OutOfWordsMessage
-          action={"back"}
-          source={source}
-          openReview={openReview}
+          message={strings.goToTextsToTranslateWords}
+          buttonText={strings.backToReading}
+          buttonAction={() => history.push("/articles")}
         />
-      </s.ExercisesColumn>
-    );
+      );
+    }
+
+    if (articleID) {
+      return (
+        <OutOfWordsMessage
+          message={strings.goStarTranslations}
+          buttonText={strings.backToWords}
+          buttonAction={() => history.goBack()}
+        />
+      );
+    }
   }
 
   function moveToNextExercise() {

--- a/src/exercises/Exercises.js
+++ b/src/exercises/Exercises.js
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
 
-import { useHistory } from "react-router-dom";
-
 import FindWordInContext from "./exerciseTypes/findWordInContext/FindWordInContext";
 import MultipleChoice from "./exerciseTypes/multipleChoice/MultipleChoice";
 import Congratulations from "./Congratulations";
@@ -34,10 +32,8 @@ let BOOKMARKS_FOR_EXERCISE = [
 export default function Exercises({
   api,
   articleID,
-  source,
-  openArticle,
-  reloadExercises,
-  openReview,
+  backToReadingAction,
+  keepExercisingAction,
 }) {
   const [countBookmarksToPractice, setCountBookmarksToPractice] = useState(
     DEFAULT_BOOKMARKS_TO_PRACTICE
@@ -53,7 +49,6 @@ export default function Exercises({
   const [isCorrect, setIsCorrect] = useState(false);
   const [showFeedbackButtons, setShowFeedbackButtons] = useState(false);
   const [reload, setReload] = useState(false);
-  const history = useHistory();
 
   useEffect(() => {
     if (exerciseSession.length === 0) {
@@ -188,8 +183,8 @@ export default function Exercises({
         correctBookmarks={correctBookmarks}
         incorrectBookmarks={incorrectBookmarks}
         api={api}
-        backToReadingAction={() => history.push("/articles")}
-        keepExercisingAction={() => window.location.reload(false)}
+        backToReadingAction={backToReadingAction}
+        keepExercisingAction={keepExercisingAction}
       />
     );
   }
@@ -199,25 +194,13 @@ export default function Exercises({
   }
 
   if (countBookmarksToPractice === 0) {
-    if (!articleID) {
-      return (
-        <OutOfWordsMessage
-          message={strings.goToTextsToTranslateWords}
-          buttonText={strings.backToReading}
-          buttonAction={() => history.push("/articles")}
-        />
-      );
-    }
-
-    if (articleID) {
-      return (
-        <OutOfWordsMessage
-          message={strings.goStarTranslations}
-          buttonText={strings.backToWords}
-          buttonAction={() => history.goBack()}
-        />
-      );
-    }
+    return (
+      <OutOfWordsMessage
+        message={strings.goToTextsToTranslateWords}
+        buttonText={strings.backToReading}
+        buttonAction={backToReadingAction}
+      />
+    );
   }
 
   function moveToNextExercise() {

--- a/src/exercises/ExercisesForArticle.js
+++ b/src/exercises/ExercisesForArticle.js
@@ -1,8 +1,19 @@
 import { useParams } from "react-router-dom";
 import Exercises from "./Exercises";
 
-export default function ExercisesForArticle({ api }) {
+export default function ExercisesForArticle({
+  api,
+  backToReadingAction,
+  keepExercisingAction,
+}) {
   let { articleID } = useParams();
 
-  return <Exercises api={api} articleID={articleID} />;
+  return (
+    <Exercises
+      api={api}
+      articleID={articleID}
+      backToReadingAction={backToReadingAction}
+      keepExercisingAction={keepExercisingAction}
+    />
+  );
 }

--- a/src/exercises/ExercisesRouter.js
+++ b/src/exercises/ExercisesRouter.js
@@ -1,4 +1,4 @@
-import { Switch } from "react-router-dom";
+import { Switch, useHistory } from "react-router-dom";
 import { PrivateRoute } from "../PrivateRoute";
 import Exercises from "./Exercises";
 import ExercisesForArticle from "./ExercisesForArticle";
@@ -9,6 +9,16 @@ import * as s from "../components/ColumnWidth.sc";
 import * as sc from "../components/TopTabs.sc";
 
 export default function ExercisesRouter({ api }) {
+  const history = useHistory();
+
+  const backToReadingAction = () => {
+    history.push("/articles");
+  };
+
+  const keepExercisingAction = () => {
+    window.location.reload(false);
+  };
+
   return (
     <s.NarrowColumn>
       <sc.TopTabs>
@@ -20,9 +30,17 @@ export default function ExercisesRouter({ api }) {
           path="/exercises/forArticle/:articleID"
           api={api}
           component={ExercisesForArticle}
+          backToReadingAction={backToReadingAction}
+          keepExercisingAction={keepExercisingAction}
         />
 
-        <PrivateRoute path="/exercises" api={api} component={Exercises} />
+        <PrivateRoute
+          path="/exercises"
+          api={api}
+          component={Exercises}
+          backToReadingAction={backToReadingAction}
+          keepExercisingAction={keepExercisingAction}
+        />
       </Switch>
     </s.NarrowColumn>
   );

--- a/src/exercises/OutOfWordsMessage.js
+++ b/src/exercises/OutOfWordsMessage.js
@@ -1,44 +1,20 @@
 import * as s from "./exerciseTypes/Exercise.sc";
 import * as sc from "../reader/ArticleReader.sc";
 import strings from "../i18n/definitions";
-import { useHistory } from "react-router-dom";
-import { EXTENSION_SOURCE } from "./Congratulations";
 
-export default function OutOfWordsMessage({ action, source, openReview }) {
-  const history = useHistory();
-
-  function onClickAction() {
-    if (source != EXTENSION_SOURCE) {
-      if (!action) {
-        return history.push("/articles");
-      } else {
-        return history.goBack();
-      }
-    }
-    else{
-      openReview()
-    }
-  }
+export default function OutOfWordsMessage({
+  message,
+  buttonAction,
+  buttonText,
+}) {
   return (
     <s.Exercise>
       <div className="contextExample">
         <h4>{strings.noTranslatedWords}</h4>
-        {!action ? (
-          <h4>{strings.goToTextsToTranslateWords}</h4>
-        ) : (
-          <h4>{strings.goStarTranslations}</h4>
-        )}
+        <h4>{message}</h4>
       </div>
       <s.BottomRow>
-        {!action ? (
-          <sc.OrangeButton onClick={onClickAction}>
-            {strings.backToReading}
-          </sc.OrangeButton>
-        ) : (
-          <sc.OrangeButton onClick={onClickAction}>
-            {strings.backToWords}
-          </sc.OrangeButton>
-        )}
+        <sc.OrangeButton onClick={buttonAction}>{buttonText}</sc.OrangeButton>
       </s.BottomRow>
     </s.Exercise>
   );

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -143,7 +143,7 @@ let strings = new LocalizedStrings(
       dec: "Dec",
       betaTesters200K:
         "📈 The beta-testers of Zeeguu have collectively reached 200'000 translations in their foreign language readings ",
-      mirceaKeynoteAtEASEAI: '👨‍🏫 Mircea gives a keynote about Zeeguu at the ',
+      mirceaKeynoteAtEASEAI: "👨‍🏫 Mircea gives a keynote about Zeeguu at the ",
       pernilleObtainsFundingPrefix:
         "👩‍🔬 Pernille Hvalsoe obtains funding from The Danish Agency for International Recruitment and Integration for a ",
       pernilleObtainsFundingLinkTitle:
@@ -278,7 +278,7 @@ let strings = new LocalizedStrings(
       starTranslation:
         "Star a translation to make it have priority in exercises.",
       ifGreyedTranslation:
-        "If a translation is grayed out, it means that Zeeguu does not think it is appropriate for exercises; to overload this decision you can star the translation.",
+        "A grayed out translation is not going to appear in exercises unless you star it.",
       theWordsYouTranslate:
         "The words you translate in the article will appear here for review",
       backToArticle: "Back to Article",
@@ -295,7 +295,7 @@ let strings = new LocalizedStrings(
       //Exercises
       wordSourceDefaultText: "your past readings",
       wordSourcePrefix: "Words in",
-      noTranslatedWords: "You have no translated words.",
+      noTranslatedWords: "You have no words to practice.",
       goToTextsToTranslateWords: "Read and translate words to get exercises.",
       goStarTranslations:
         "Go back and star translations for Zeeguu to include them in your exercises.",
@@ -485,7 +485,8 @@ let strings = new LocalizedStrings(
         "Are you sure you want to delete this class? This cannot be undone.",
       cannotDeleteClassWithText:
         "Something went wrong. If you still share texts with this class, you cannot remove it from your list. Please, check that in 'My texts' and try again.",
-      youAreSharingThisClassWarning: "You are sharing this class with at least one colleague. If you delete it here, you also irreversibly delete it from their list of classes.",
+      youAreSharingThisClassWarning:
+        "You are sharing this class with at least one colleague. If you delete it here, you also irreversibly delete it from their list of classes.",
 
       //DeleteStudentWarning
       wishToDeleteStudent: "Do you wish to remove",
@@ -504,11 +505,15 @@ let strings = new LocalizedStrings(
       saveText: "Save Text",
 
       //ShareTextWithColleagueDialog
-      somethingWentWrongMostLikelyEmail: "Something went wrong. Most likely, the email is not registered in Zeeguu. Please, try a different one.",
-      theConnectionFailed: "The connection to the server seems unstable at the moment. Please, let us know if this continues to happen.",
-      enterEmailYourColleagueUse: "Enter the email, your colleague use for Zeeguu.",
+      somethingWentWrongMostLikelyEmail:
+        "Something went wrong. Most likely, the email is not registered in Zeeguu. Please, try a different one.",
+      theConnectionFailed:
+        "The connection to the server seems unstable at the moment. Please, let us know if this continues to happen.",
+      enterEmailYourColleagueUse:
+        "Enter the email, your colleague use for Zeeguu.",
       share: "Share",
-      yourColleagueShouldHaveTheTextShortly: "Your colleague should be able to find the text under 'My Texts' in a moment.",
+      yourColleagueShouldHaveTheTextShortly:
+        "Your colleague should be able to find the text under 'My Texts' in a moment.",
       ok: "OK",
 
       //TooltipedButtons
@@ -1156,7 +1161,8 @@ let strings = new LocalizedStrings(
         "Er du sikker på, at du vil slette denne klasse? Du kan ikke fortryde.",
       cannotDeleteClassWithText:
         "Noget gik galt. Hvis du deler tekster med denne klasse, kan du ikke slette klassen. Fjern delte tekster med denne klasse i 'Mine tekster', og prøv igen.",
-      youAreSharingThisClassWarning: "Du deler denne klasse med mindst én kollega. Hvis du sletter klassen her, bliver den også uigenkaldeligt slettet fra din kollegas list af klasser.",
+      youAreSharingThisClassWarning:
+        "Du deler denne klasse med mindst én kollega. Hvis du sletter klassen her, bliver den også uigenkaldeligt slettet fra din kollegas list af klasser.",
 
       //DeleteStudentWarning
       wishToDeleteStudent: "Ønsker du at fjerne",
@@ -1175,11 +1181,15 @@ let strings = new LocalizedStrings(
       saveText: "Gem tekst",
 
       //ShareTextWithColleagueDialog
-      somethingWentWrongMostLikelyEmail: "Noget gik galt. Det kan være din kollega bruger en anden email til Zeeguu. Tjek venligst og prøv igen.",
-      theConnectionFailed: "Forbindelsen til serveren virker ustabil. Giv os gerne besked, hvis dette problem fortsætter.",
-      enterEmailYourColleagueUse: "Indsæt den email, din kollega bruger til Zeeguu",
+      somethingWentWrongMostLikelyEmail:
+        "Noget gik galt. Det kan være din kollega bruger en anden email til Zeeguu. Tjek venligst og prøv igen.",
+      theConnectionFailed:
+        "Forbindelsen til serveren virker ustabil. Giv os gerne besked, hvis dette problem fortsætter.",
+      enterEmailYourColleagueUse:
+        "Indsæt den email, din kollega bruger til Zeeguu",
       share: "Del",
-      yourColleagueShouldHaveTheTextShortly: "Din kollega burde have teksten i 'Mine tekster' om et øjeblik.",
+      yourColleagueShouldHaveTheTextShortly:
+        "Din kollega burde have teksten i 'Mine tekster' om et øjeblik.",
       ok: "OK",
 
       //TooltipedButtons

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -84,20 +84,32 @@ export default function ArticleReader({ api, teacherArticleID }) {
       api.logReaderActivity(api.OPEN_ARTICLE, articleID, "", UMR_SOURCE);
     });
 
-    window.addEventListener("focus", function(){onFocus(api, articleID, UMR_SOURCE)});
-    window.addEventListener("blur", function(){onBlur(api, articleID, UMR_SOURCE)});
+    window.addEventListener("focus", function () {
+      onFocus(api, articleID, UMR_SOURCE);
+    });
+    window.addEventListener("blur", function () {
+      onBlur(api, articleID, UMR_SOURCE);
+    });
     document
       .getElementById("scrollHolder")
-      .addEventListener("scroll", function(){onScroll(api, articleID, UMR_SOURCE)});
+      .addEventListener("scroll", function () {
+        onScroll(api, articleID, UMR_SOURCE);
+      });
 
     return () => {
-      window.removeEventListener("focus", function(){onFocus(api, articleID, UMR_SOURCE)});
-      window.removeEventListener("blur", function(){onBlur(api, articleID, UMR_SOURCE)});
+      window.removeEventListener("focus", function () {
+        onFocus(api, articleID, UMR_SOURCE);
+      });
+      window.removeEventListener("blur", function () {
+        onBlur(api, articleID, UMR_SOURCE);
+      });
 
       document.getElementById("scrollHolder") !== null &&
         document
           .getElementById("scrollHolder")
-          .removeEventListener("scroll", function(){onScroll(api, articleID, UMR_SOURCE)});
+          .removeEventListener("scroll", function () {
+            onScroll(api, articleID, UMR_SOURCE);
+          });
       api.logReaderActivity("ARTICLE CLOSED", articleID, "", UMR_SOURCE);
     };
     // eslint-disable-next-line
@@ -186,7 +198,10 @@ export default function ArticleReader({ api, teacherArticleID }) {
             className={pronouncing ? "selected" : ""}
             onClick={(e) => toggle(pronouncing, setPronouncing)}
           >
-            <img src="https://zeeguu.org/static/images/sound.svg" alt={strings.listenOnClick} />
+            <img
+              src="https://zeeguu.org/static/images/sound.svg"
+              alt={strings.listenOnClick}
+            />
             <span className="tooltiptext">{strings.listenOnClick}</span>
           </button>
         </s.Toolbar>
@@ -254,9 +269,9 @@ export default function ArticleReader({ api, teacherArticleID }) {
         <br />
         <br />
         <s.CenteredContent>
-          <Link to={`/words/forArticle/${articleID}`}>
-            <s.OrangeButton>{strings.reviewVocabulary}</s.OrangeButton>
-          </Link>
+          <s.NavigationLink primary to={`/words/forArticle/${articleID}`}>
+            {strings.reviewVocabulary}
+          </s.NavigationLink>
         </s.CenteredContent>
       </s.FeedbackBox>
       <s.ExtraSpaceAtTheBottom />

--- a/src/reader/ArticleReader.sc.js
+++ b/src/reader/ArticleReader.sc.js
@@ -2,13 +2,20 @@ import styled, { css } from "styled-components";
 
 import { BigSquareButton } from "../components/allButtons.sc";
 
-import { veryLightGrey, zeeguuLightYellow, zeeguuOrange, zeeguuVarmYellow } from "../components/colors";
+import {
+  veryLightGrey,
+  zeeguuLightYellow,
+  zeeguuOrange,
+  zeeguuVarmYellow,
+} from "../components/colors";
 
 import {
   NarrowColumn,
   CenteredContent,
   ContentOnRow,
 } from "../components/ColumnWidth.sc";
+
+import { Link } from "react-router-dom";
 
 let ArticleReader = styled.div`
   max-width: 768px;
@@ -139,6 +146,67 @@ let OrangeButton = styled(_BottomButton)`
   }
 `;
 
+let NavigationLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  min-width: 8em;
+  min-height: 2em;
+  padding: 0.5em;
+  margin-left: 1em;
+
+  @media (min-wdith: 768px) {
+    width: 16em;
+  }
+
+  // Next
+  ${(props) =>
+    props.next &&
+    css`
+      :after {
+        content: ">>";
+      }
+    `}
+  // Previous
+  ${(props) =>
+    props.prev &&
+    css`
+      :before {
+        content: " <<";
+      }
+    `}
+
+  // Primary
+  ${(props) =>
+    props.primary &&
+    css`
+      background-color: orange !important;
+      color: white !important;
+      border-color: ${zeeguuOrange};
+      border-style: solid;
+      border-width: 2px;
+      border-radius: 10px;
+    `}
+  // Secondary
+  ${(props) =>
+    props.secondary &&
+    css`
+      background-color: white !important;
+      color: orange !important;
+    `}
+    // Disabled
+    ${(props) =>
+    props.disabled &&
+    css`
+      background-color: white !important;
+      color: #999999 !important;
+      cursor: not-allowed;
+      pointer-events: none;
+      border-width: 0;
+    `}
+`;
+
 let FeedbackBox = styled.div`
   border: 1px solid lightgray;
   background-color: ${veryLightGrey};
@@ -181,4 +249,5 @@ export {
   ExtraSpaceAtTheBottom,
   NarrowColumn,
   ContentOnRow,
+  NavigationLink,
 };

--- a/src/words/Word.js
+++ b/src/words/Word.js
@@ -9,6 +9,8 @@ export default function Word({
   bookmark,
   notifyUnstar,
   notifyDelete,
+  notifyStar,
+  notifyEdit,
   children,
   api,
   hideStar,
@@ -29,14 +31,16 @@ export default function Word({
       api.unstarBookmark(bookmark.id);
       bookmark.starred = false;
       setStarred(false);
+      if (notifyUnstar) {
+        notifyUnstar(bookmark);
+      }
     } else {
       api.starBookmark(bookmark.id);
       setStarred(true);
       bookmark.starred = true;
-    }
-
-    if (notifyUnstar) {
-      notifyUnstar(bookmark);
+      if (notifyStar) {
+        notifyStar(bookmark);
+      }
     }
   }
 

--- a/src/words/WordsForArticle.js
+++ b/src/words/WordsForArticle.js
@@ -4,19 +4,24 @@ import { useState, useEffect } from "react";
 import LoadingAnimation from "../components/LoadingAnimation";
 import WordsToReview from "./WordsToReview";
 import { NarrowColumn, CenteredContent } from "../components/ColumnWidth.sc";
-import {OrangeButton, WhiteButton} from "../reader/ArticleReader.sc";
+import { NavigationLink } from "../reader/ArticleReader.sc";
 import { setTitle } from "../assorted/setTitle";
 import strings from "../i18n/definitions";
+
+function fit_for_study(words) {
+  return words.filter((b) => b.fit_for_study || b.starred).length > 0;
+}
 
 export default function WordsForArticle({ api }) {
   let { articleID } = useParams();
   const [words, setWords] = useState(null);
   const [articleInfo, setArticleInfo] = useState(null);
+  const [exercisesEnabled, setExercisesEnabled] = useState(false);
 
   useEffect(() => {
     api.bookmarksForArticle(articleID, (bookmarks) => {
       setWords(bookmarks);
-      console.dir(bookmarks);
+      setExercisesEnabled(fit_for_study(bookmarks));
     });
     api.getArticleInfo(articleID, (data) => {
       setArticleInfo(data);
@@ -33,26 +38,48 @@ export default function WordsForArticle({ api }) {
   }
 
   function deleteBookmark(bookmark) {
-    setWords(words.filter((e) => e.id !== bookmark.id));
+    let newWords = words.filter((e) => e.id !== bookmark.id);
+    setWords(newWords);
+    setExercisesEnabled(fit_for_study(newWords));
+  }
+
+  function notifyWordChanged() {
+    setExercisesEnabled(fit_for_study(words));
+  }
+
+  function logGoingToExercisesAfterReview(e) {
+    api.logReaderActivity(
+      api.TO_EXERCISES_AFTER_REVIEW,
+      articleID,
+      "",
+      UMR_SOURCE
+    );
   }
 
   return (
     <NarrowColumn>
-      <WordsToReview words={words} deleteBookmark={deleteBookmark} articleInfo={articleInfo} api={api}/>
+      <WordsToReview
+        words={words}
+        deleteBookmark={deleteBookmark}
+        articleInfo={articleInfo}
+        api={api}
+        notifyWordChanged={notifyWordChanged}
+      />
+
       <CenteredContent>
-        <Link to={`/read/article?id=${articleID}`}>
-          <WhiteButton>{strings.backToArticle}</WhiteButton>
-        </Link>
-        {words.length > 0 && (
-          <Link
-            to={`/exercises/forArticle/${articleID}`}
-            onClick={(e) =>
-              api.logReaderActivity(api.TO_EXERCISES_AFTER_REVIEW, articleID, "", UMR_SOURCE)
-            }
-          >
-            <OrangeButton>{strings.toExercises}</OrangeButton>
-          </Link>
-        )}
+        <NavigationLink prev secondary to={`/read/article?id=${articleID}`}>
+          {strings.backToArticle}
+        </NavigationLink>
+
+        <NavigationLink
+          primary
+          next
+          {...(exercisesEnabled || { disabled: true })}
+          to={`/exercises/forArticle/${articleID}`}
+          onClick={logGoingToExercisesAfterReview}
+        >
+          {strings.toExercises}
+        </NavigationLink>
       </CenteredContent>
     </NarrowColumn>
   );

--- a/src/words/WordsToReview.js
+++ b/src/words/WordsToReview.js
@@ -1,46 +1,51 @@
 import Word from "./Word";
 import { TopMessage } from "../components/TopMessage.sc";
-import {ContentOnRow,} from "../reader/ArticleReader.sc";
+import { ContentOnRow } from "../reader/ArticleReader.sc";
 import strings from "../i18n/definitions";
 
-export default function WordsToReview({words, articleInfo, deleteBookmark, api}) {
-    return (
-        <>
-        <br />
-        <h1>{strings.ReviewTranslations}</h1>
-        <small>{strings.from}{articleInfo.title}</small>
-        <br />
-        <br />
-        <br />
-        <TopMessage style={{ textAlign: "left" }}>
-          {words.length > 0 ? (
-            <>
-              * {strings.deleteTranslation}
-              <br />
-              <br />
-              * {strings.starTranslation}
-              <br />
-              <br />
-              * {strings.ifGreyedTranslation}
-              <br />
-            </>
-          ) : (
-            strings.theWordsYouTranslate
-          )}
-        </TopMessage>
-        {words.map((each) => (
-          <ContentOnRow>
-            <Word
-              key={each.id}
-              bookmark={each}
-              notifyDelete={deleteBookmark}
-              api={api}
-            />
-          </ContentOnRow>
-        ))}
-        <br />
-        <br />
-        <br />  
-        </>
-    );
+export default function WordsToReview({
+  words,
+  articleInfo,
+  deleteBookmark,
+  api,
+  notifyWordChanged,
+}) {
+  return (
+    <>
+      <h1>{strings.ReviewTranslations}</h1>
+      <small>
+        {strings.from}
+        {articleInfo.title}
+      </small>
+
+      <br />
+      <br />
+      <TopMessage style={{ textAlign: "left" }}>
+        {words.length > 0 ? (
+          <>
+            <p>{strings.deleteTranslation}</p>
+            <p>{strings.starTranslation}</p>
+            <p>{strings.ifGreyedTranslation}</p>
+          </>
+        ) : (
+          strings.theWordsYouTranslate
+        )}
+      </TopMessage>
+      {words.map((each) => (
+        <ContentOnRow>
+          <Word
+            key={each.id}
+            bookmark={each}
+            notifyDelete={deleteBookmark}
+            api={api}
+            notifyStar={notifyWordChanged}
+            notifyUnstar={notifyWordChanged}
+          />
+        </ContentOnRow>
+      ))}
+      <br />
+      <br />
+      <br />
+    </>
+  );
 }


### PR DESCRIPTION
It's hard to explain, but the propagation of `if source==...` in components feels wrong. 

I guess the principle should be that the component should be reusable without knowing too much about the business of its parents. The fact that the extension prefers one action and the reader prefers another action should be their corresponding business, so it should not be in the component. 

The proposed solution extracts the differences into parameters. For OutOfWordsMessage it's new usage looks like this: 

<img width="915" alt="image" src="https://user-images.githubusercontent.com/464519/158888010-71914259-38bc-4d77-850c-43296df2ab17.png">

Similarily Congratulations has now more behavior injected into it:

<img width="915" alt="image" src="https://user-images.githubusercontent.com/464519/158888084-be6e3619-1e47-4ada-b968-f95104895a0f.png">

The two components implementation is now simplified. I also removed the source prop which is not needed. 

Also, I've refactored the names of the props, so you'll have to update the extension.
If the two codebases were together I could have refactored also your code in the extension... we should really try to bring the extension into the same repository as the Zeeguu-react. Then this kind of situation will not happen anymore!