### PR TITLE
e.preventDefault is not a function bug

### DIFF
--- a/src/exercises/exerciseTypes/findWordInContext/FindWordInContext.js
+++ b/src/exercises/exerciseTypes/findWordInContext/FindWordInContext.js
@@ -71,7 +71,7 @@ export default function FindWordInContext({
 
   function notifyBookmarkTranslation() {
     let concatMessage = messageToAPI + "T";
-    handleShowSolution(concatMessage);
+    handleShowSolution(undefined, concatMessage);
   }
 
   function inputKeyPress() {
@@ -81,7 +81,9 @@ export default function FindWordInContext({
   }
 
   function handleShowSolution(e, message) {
-    e.preventDefault()
+    if (e) {
+      e.preventDefault();
+    }
     let pressTime = new Date();
     console.log(pressTime - initialTime);
     console.log("^^^^ time elapsed");


### PR DESCRIPTION
If notifyBookMarkTranslation is called the website crashes, because handleShowSolution is only given one parameter - a message - but it expect an event and then a message. Inside of handleShowSolution the event then contains the message - and the message does not have a preventDefault() - and then the site crashes.