### PR TITLE
Login and logout from extension

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { BrowserRouter, Switch, Route } from "react-router-dom";
 import LandingPage from "./landingPage/LandingPage";
 import SignIn from "./pages/SignIn";
@@ -36,6 +36,16 @@ function App() {
 
   const [user, setUser] = useState(userDict);
 
+  //resets user on zeeguu.org if they log out of the extension
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!getUserSession()) {
+          setUser({})
+      }
+    }, 1000);
+    return () => clearInterval(interval); 
+  }, [])
+  
   function handleSuccessfulSignIn(userInfo, history) {
     setUser({
       session: api.session,

--- a/src/PrivateRoute.js
+++ b/src/PrivateRoute.js
@@ -1,7 +1,6 @@
 import React, { useContext } from "react";
 import { Route, Redirect } from "react-router-dom";
 import { UserContext } from "./UserContext";
-import { getUserSession } from "./utils/cookies/userInfo";
 
 // inspired from:
 // https://dev.to/mychal/protected-routes-with-react-function-components-dh
@@ -12,7 +11,7 @@ import { getUserSession } from "./utils/cookies/userInfo";
 const PrivateRoute = ({ component: Component, ...rest }) => {
   const user = useContext(UserContext);
 
-  if (!getUserSession()) {
+  if (!user.session) {
     return <Redirect to={{ pathname: "/login" }} />;
   }
   return (

--- a/src/PrivateRoute.js
+++ b/src/PrivateRoute.js
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { Route, Redirect } from "react-router-dom";
 import { UserContext } from "./UserContext";
+import { getUserSession } from "./utils/cookies/userInfo";
 
 // inspired from:
 // https://dev.to/mychal/protected-routes-with-react-function-components-dh
@@ -11,7 +12,7 @@ import { UserContext } from "./UserContext";
 const PrivateRoute = ({ component: Component, ...rest }) => {
   const user = useContext(UserContext);
 
-  if (!user.session) {
+  if (!getUserSession()) {
     return <Redirect to={{ pathname: "/login" }} />;
   }
   return (


### PR DESCRIPTION
Hi Mircea

I could not get the login and logout to work with the cookies. I changed the PrivateRoute, so that it checks for the cookie instead of the session in the context - and it fixed the problem, but only when you switch between routes. However, if you click around inside one route, it will not redirect back to login, when the cookie is gone.

So I’m thinking we need a way to check if there is a cookie every time the user clicks on something. Or zeeguu should re-render, if the cookie is removed or set. Or maybe we can check if the cookie is there every time a certain time has passed?
I’m not sure what the best solution is, or what is possible. Do you have any ideas?