### PR TITLE
ifGrayedTranslation definition changed

### DIFF
--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -278,7 +278,7 @@ let strings = new LocalizedStrings(
       starTranslation:
         "Starred translations have priority in exercises.",
       ifGreyedTranslation:
-        "A grayed out translation won't appear in exercises unless you star it.",
+      "Translations are grayed out because they are not suitable for the exercises. Star them if you disagree.",
       theWordsYouTranslate:
         "The words you translate in the article will appear here for review",
       backToArticle: "Back to Article",


### PR DESCRIPTION
Instead of making a little popover explaining the grayed out words, I changed the text, because I noticed that the danish string definition was a bit different and more detailed. Now the english and danish one are more similar.