### PR TITLE
Install extension after created account

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,13 +10,14 @@ import LoggedInRouter from "./LoggedInRouter";
 import CreateAccount from "./pages/CreateAccount";
 import ResetPassword from "./pages/ResetPassword";
 import useUILanguage from "./assorted/hooks/uiLanguageHook";
-
+import { checkExtensionInstalled } from "./utils/misc/extensionCommunication";
 import ExtensionInstalled from "./pages/ExtensionInstalled";
 import {
   getUserSession,
   saveUserInfoIntoCookies,
   removeUserInfoFromCookies,
 } from "./utils/cookies/userInfo";
+import InstallExtension from "./pages/InstallExtension";
 
 function App() {
   let userDict = {};
@@ -37,6 +38,8 @@ function App() {
   const [api] = useState(_api);
 
   const [user, setUser] = useState(userDict);
+  const [hasExtension, setHasExtension] = useState(false);
+
 
   //resets user on zeeguu.org if they log out of the extension
   useEffect(() => {
@@ -45,6 +48,7 @@ function App() {
         setUser({});
       }
     }, 1000);
+    checkExtensionInstalled(setHasExtension)
     return () => clearInterval(interval);
   }, []);
 
@@ -63,9 +67,13 @@ function App() {
     // between the extension and the website
     saveUserInfoIntoCookies(userInfo, api.session);
 
-    userInfo.is_teacher
-      ? history.push("/teacher/classes")
-      : history.push("/articles");
+    if (window.location.href.indexOf("create_account") > -1 && !hasExtension) {
+      history.push("/install_extension");
+    } else {
+      userInfo.is_teacher
+        ? history.push("/teacher/classes")
+        : history.push("/articles");
+    }
   }
 
   function logout() {
@@ -106,6 +114,11 @@ function App() {
               path="/extension_installed"
               render={() => <ExtensionInstalled />}
             />
+
+            <Route
+               path="/install_extension"
+               render={() => <InstallExtension />}
+             />
 
             <Route
               path="/reset_pass"

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -524,12 +524,16 @@ let strings = new LocalizedStrings(
 
       // New user created
       userCreated: "Welcome to Zeeguu",
-      installExtension: " Remember to install the Chrome extension",
-      extensionDescription: "The extension \"The Zeeguu Reader\" helps you read articles in the language that you want to practice and offers one-click translation and pronunciation.",
-      extensionFunctionality: "The Zeeguu Reader allows you to enrich your vocabulary in a foreign language while you browse the web and read articles that are interesting to you. It supports you in the following way:" ,
-      extensionAdvantage1: "You read articles in the language that you want to practice; these could be articles on news sites, blogs, or encyclopedias like Wikipedia.",
-      extensionAdvantage2: "For better readability, the extension removes all excess clutter, like adverts, buttons, and videos from the article",
-      extensionAdvantage3: "The extension then generates personalized vocabulary exercises by using the original context in which you encountered words that you didn't understand.",
+      installExtension: " Time to install the Zeeguu Reader Chrome extension",
+      extensionDescription:
+        "Here on zeeguu.org you can see your words, find article recommendation links, do exercises, see statistics, etc. You can also read, but only articles that were shared with you by your teacher, or articles that you have saved from the extension.",
+      extensionFunctionality:
+        "When you follow an article recommendation link, or you find an article on the net, you should activate the extension which:",
+      extensionAdvantage1: "Offers you one-click translation and pronunciation",
+      extensionAdvantage2:
+        "Removes all excess clutter, like adverts, buttons, and videos from the article",
+      extensionAdvantage3:
+        "Generates personalized vocabulary exercises by using the original context in which you encountered words that you didn't understand.",
 
       //Extension installed
       goToArticles: "Go to articles",
@@ -609,7 +613,6 @@ let strings = new LocalizedStrings(
       urdu: "Urdu",
       tamil: "Tamil",
       bengali: "Bengali",
-
 
       //NoStudents
       noStudentsInClass: "There are no students in this class yet.",
@@ -1305,7 +1308,6 @@ let strings = new LocalizedStrings(
       urdu: "Urdu",
       tamil: "Tamil",
       bengali: "Bengali",
-      
 
       //NoStudents
       noStudentsInClass: "Der er ikke nogen elever i denne klasse endnu.",

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -174,7 +174,7 @@ let strings = new LocalizedStrings(
       contributors: "Contributors",
 
       //ArticleRouter
-      findTab: "Recommendations",
+      findTab: "Recommended",
       classroomTab: "Classroom",
       bookmarkedTab: "Bookmarked",
       myTextsTab: "My Texts",

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -522,6 +522,15 @@ let strings = new LocalizedStrings(
         "Your colleague should be able to find the text under 'My Texts' in a moment.",
       ok: "OK",
 
+      // New user created
+      userCreated: "Welcome to Zeeguu",
+      installExtension: " Remember to install the Chrome extension",
+      extensionDescription: "The extension \"The Zeeguu Reader\" helps you read articles in the language that you want to practice and offers one-click translation and pronunciation.",
+      extensionFunctionality: "The Zeeguu Reader allows you to enrich your vocabulary in a foreign language while you browse the web and read articles that are interesting to you. It supports you in the following way:" ,
+      extensionAdvantage1: "You read articles in the language that you want to practice; these could be articles on news sites, blogs, or encyclopedias like Wikipedia.",
+      extensionAdvantage2: "For better readability, the extension removes all excess clutter, like adverts, buttons, and videos from the article",
+      extensionAdvantage3: "The extension then generates personalized vocabulary exercises by using the original context in which you encountered words that you didn't understand.",
+
       //Extension installed
       goToArticles: "Go to articles",
       pinExtension: "Pin it to the toolbar to make it easy to access.",

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -536,7 +536,7 @@ let strings = new LocalizedStrings(
         "Generates personalized vocabulary exercises by using the original context in which you encountered words that you didn't understand.",
 
       //Extension installed
-      goToArticles: "Go to articles",
+      goToArticles: "Go to article recommendations",
       pinExtension: "Pin it to the toolbar to make it easy to access.",
       congratulations: "Extension is installed!",
 

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -174,7 +174,7 @@ let strings = new LocalizedStrings(
       contributors: "Contributors",
 
       //ArticleRouter
-      findTab: "Find",
+      findTab: "Recommendations",
       classroomTab: "Classroom",
       bookmarkedTab: "Bookmarked",
       myTextsTab: "My Texts",

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -70,10 +70,7 @@ export default function CreateAccount({ api, signInAndRedirect }) {
       password,
       userInfo,
       (session) => {
-        // if the created user is a teacher, we only know
-        // by asking the api; so we do that
-        api.isTeacher((teacher_status) => {
-          userInfo["is_teacher"] = teacher_status === "True";
+        api.getUserDetails((userInfo) => {
           signInAndRedirect(userInfo, history);
         });
       },

--- a/src/pages/InstallExtension.js
+++ b/src/pages/InstallExtension.js
@@ -1,0 +1,35 @@
+import { LogoOnTop } from "../components/FormPage.sc";
+import strings from "../i18n/definitions";
+import { PageBackground, ExtensionContainer } from "./ExtensionInstalled.sc";
+import * as s from "./InstallExtension.sc";
+
+export default function InstallExtension() {
+  return (
+    <PageBackground>
+      <LogoOnTop />
+      <ExtensionContainer>
+        <s.InstallExtensionWrapper>
+          <h1>{strings.userCreated}</h1>
+          <h4>{strings.installExtension}</h4>
+          <p>{strings.extensionDescription}</p>
+          <p>{strings.extensionFunctionality}</p>
+          <ul>
+            <li><p>{strings.extensionAdvantage1}</p></li>
+            <li> <p>{strings.extensionAdvantage2}</p></li>
+            <li> <p>{strings.extensionAdvantage3}</p></li>
+          </ul>
+          <s.LinkContainer>
+            <s.OrangeButton>
+              <a href="https://chrome.google.com/webstore/detail/the-zeeguu-reader/ckncjmaednfephhbpeookmknhmjjodcd">
+                Install "The Zeeguu Reader"
+              </a>
+            </s.OrangeButton>
+            <a href="/articles">
+                Don't want the extension? Go to articles.
+              </a>
+          </s.LinkContainer>
+        </s.InstallExtensionWrapper>
+      </ExtensionContainer>
+    </PageBackground>
+  );
+}

--- a/src/pages/InstallExtension.sc.js
+++ b/src/pages/InstallExtension.sc.js
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import { zeeguuOrange } from "../components/colors";
+
+const InstallExtensionWrapper = styled.div`
+  img {
+    width: 100%;
+  }
+  h1 {
+    margin-block-start: 0em;
+    margin-block-end: 0em;
+    text-align: center;
+  }
+
+  h4 {
+    text-align: center;
+  }
+
+  p {
+    font-size: 0.9em;
+    margin-block-end: 0em;
+  }
+`;
+
+const OrangeButton = styled.button`
+  height: 4em;
+  width: 30em;
+  margin: 0em 1em 1em 1em;
+  background: ${zeeguuOrange};
+  border: 0.3em solid ${zeeguuOrange};
+  border-radius: 7em;
+
+  a {
+    font-weight: 600;
+    font-size: 1.5em !important;
+    color: white;
+  }
+`;
+
+let LinkContainer = styled.div`
+  margin: 0.8em;
+  display: flex;
+  justify-content: space-evenly;
+  flex-flow: wrap;
+  a {
+    font-size: small;
+  }
+`;
+
+export { InstallExtensionWrapper, OrangeButton, LinkContainer };


### PR DESCRIPTION
When users create an account we check if they have the extension - if they do not we send them to the new page "install_extension". We only do this if handleSuccessfulSignIn is called from zeeguu.org/create_account