### PR TITLE
Animation clicked word

### DIFF
--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -1,5 +1,10 @@
 import styled from "styled-components";
-import { almostBlack, zeeguuLightYellow, zeeguuOrange, zeeguuVeryLightYellow } from "../components/colors";
+import {
+  almostBlack,
+  zeeguuLightYellow,
+  zeeguuOrange,
+  zeeguuVeryLightYellow,
+} from "../components/colors";
 
 const TranslatableText = styled.div`
   z-tag {
@@ -14,7 +19,6 @@ const TranslatableText = styled.div`
   z-tag.loading {
     animation: blink 1.5s linear infinite;
     color: ${zeeguuOrange};
-    //animation: blinker 1s linear infinite;
   }
   @keyframes blink {
     0% {
@@ -27,14 +31,6 @@ const TranslatableText = styled.div`
       opacity: 1;
     }
   }
-  //@keyframes blinker {
-  //  0% {
-  //    border-bottom: 1px dashed rgb(255, 187, 84, 0);
-  //  }
-  //  100% {
-  //    border-bottom: 1px dashed rgb(255, 187, 84, 1);
-  //  }
-  //}
 
   /*  z-tag tag hover changes color, translated word hover no underline or color*/
 

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -61,6 +61,34 @@ const TranslatableText = styled.div`
     color: ${zeeguuOrange};
   }
 
+  z-tag#loading {
+    animation: blink 1.5s linear infinite;
+    color: ${zeeguuOrange};
+    //animation: blinker 1s linear infinite;
+  }
+
+  @keyframes blink {
+    0% {
+      opacity: 0.2;
+    }
+    50% {
+      opacity: 0.7;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  //@keyframes blinker {
+  //  0% {
+  //    border-bottom: 1px dashed rgb(255, 187, 84, 0);
+  //  }
+  //  100% {
+  //    border-bottom: 1px dashed rgb(255, 187, 84, 1);
+  //  }
+  //}
+
+
   /* when there are multiple translations, we mark this with a little
 green downwards pointing triangle; we used to mark also single alternatives
  but for now there's no marking for them */

--- a/src/reader/TranslatableText.sc.js
+++ b/src/reader/TranslatableText.sc.js
@@ -12,8 +12,29 @@ const TranslatableText = styled.div`
   }
 
   z-tag.loading {
-    animation: fadein 1s 0s infinite linear alternate;
+    animation: blink 1.5s linear infinite;
+    color: ${zeeguuOrange};
+    //animation: blinker 1s linear infinite;
   }
+  @keyframes blink {
+    0% {
+      opacity: 0.2;
+    }
+    50% {
+      opacity: 0.7;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+  //@keyframes blinker {
+  //  0% {
+  //    border-bottom: 1px dashed rgb(255, 187, 84, 0);
+  //  }
+  //  100% {
+  //    border-bottom: 1px dashed rgb(255, 187, 84, 1);
+  //  }
+  //}
 
   /*  z-tag tag hover changes color, translated word hover no underline or color*/
 
@@ -60,34 +81,6 @@ const TranslatableText = styled.div`
     width: 100%;
     color: ${zeeguuOrange};
   }
-
-  z-tag#loading {
-    animation: blink 1.5s linear infinite;
-    color: ${zeeguuOrange};
-    //animation: blinker 1s linear infinite;
-  }
-
-  @keyframes blink {
-    0% {
-      opacity: 0.2;
-    }
-    50% {
-      opacity: 0.7;
-    }
-    100% {
-      opacity: 1;
-    }
-  }
-
-  //@keyframes blinker {
-  //  0% {
-  //    border-bottom: 1px dashed rgb(255, 187, 84, 0);
-  //  }
-  //  100% {
-  //    border-bottom: 1px dashed rgb(255, 187, 84, 1);
-  //  }
-  //}
-
 
   /* when there are multiple translations, we mark this with a little
 green downwards pointing triangle; we used to mark also single alternatives

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -13,11 +13,11 @@ export default function TranslatableWord({
   const [showingAlternatives, setShowingAlternatives] = useState(false);
 
   function clickOnWord(e, word) {
-    e.target.id = "loading"   
+    e.target.className = "loading"  
     if (translating) {
       interactiveText.translate(word, () => {
         wordUpdated();
-        e.target.id = null; 
+        e.target.className = null; 
       });
       if (translatedWords) {
         let copyOfWords = [...translatedWords];

--- a/src/reader/TranslatableWord.js
+++ b/src/reader/TranslatableWord.js
@@ -12,10 +12,12 @@ export default function TranslatableWord({
 }) {
   const [showingAlternatives, setShowingAlternatives] = useState(false);
 
-  function clickOnWord(word) {
+  function clickOnWord(e, word) {
+    e.target.id = "loading"   
     if (translating) {
       interactiveText.translate(word, () => {
         wordUpdated();
+        e.target.id = null; 
       });
       if (translatedWords) {
         let copyOfWords = [...translatedWords];
@@ -60,7 +62,7 @@ export default function TranslatableWord({
   if (!word.translation) {
     return (
       <>
-        <z-tag onClick={(e) => clickOnWord(word)}>{word.word}</z-tag>
+        <z-tag onClick={(e) => clickOnWord(e, word)}>{word.word}</z-tag>
         <span> </span>
       </>
     );


### PR DESCRIPTION
Proposed suggestion to this one: https://github.com/zeeguu-ecosystem/zeeguu-react/issues/192

We actually also had a user in our usability test who clicked multiple times on a word, because nothing happened fast enough. 

There are two different loading animations here. One is commented out. That is the one with the blinking underline. It doesn't look that good - and I can't get the animated blinking line to align with the permanent line. So when the translation is loaded - which is quick - then it jumps up higher. Because it is also so quick to load most of the time I think it might look better to load the word itself.

So that is what I tried here. The word will blink until it is loaded. So maybe that could be an alternative. But the underline blinker is there, if you want to see how that looks. 

I looked through old code, and you did have the  z-tag.loading{} - but I could not find a version of zeeguu where a loading class was implemented. And then it used a fadein which was not defined. 