### PR TITLE
Fixing the jumping icons

### DIFF
--- a/src/pages/ExtensionInstalled.js
+++ b/src/pages/ExtensionInstalled.js
@@ -13,7 +13,7 @@ export default function ExtensionInstalled() {
           <h4>{strings.pinExtension}</h4>
 
           <img
-            src={"/static/images/zeeguuExtension.gif"}
+            src={"https://zeeguu.org/static/images/zeeguuExtension.gif"}
             alt="How to pin Chrome Extension to Chrome Toolbar gif"
           />
           <s.LinkContainer>

--- a/src/reader/ArticleReader.js
+++ b/src/reader/ArticleReader.js
@@ -192,7 +192,7 @@ export default function ArticleReader({ api, teacherArticleID }) {
               src="https://zeeguu.org/static/images/translate.svg"
               alt={strings.translateOnClick}
             />
-            <span className="tooltiptext">{strings.translateOnClick}</span>
+            <div className="tooltiptext">{strings.translateOnClick}</div>
           </button>
           <button
             className={pronouncing ? "selected" : ""}
@@ -202,7 +202,7 @@ export default function ArticleReader({ api, teacherArticleID }) {
               src="https://zeeguu.org/static/images/sound.svg"
               alt={strings.listenOnClick}
             />
-            <span className="tooltiptext">{strings.listenOnClick}</span>
+            <div className="tooltiptext">{strings.listenOnClick}</div>
           </button>
         </s.Toolbar>
       </PopupButtonWrapper>


### PR DESCRIPTION
I could not let it go. I realised that the jumping "translation" and "pronunciation" buttons were also jumping when you read articles on zeeguu.org. 

This should fix it. The hidden span tooltip text was pushing the button as it loaded. Making it block-line should fix that issue - so, I made it into a div instead. Minor stuff though; no need to update the extension yet - and no rush to look at it straight away :)  