### PR TITLE
Cross browser extension

### DIFF
--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -11,7 +11,7 @@ import Reminder from "./Reminder";
 import ExtensionMessage from "../components/ExtensionMessage";
 import Feature from "../features/Feature";
 import LocalStorage from "../assorted/LocalStorage";
-import { runningInChromeDesktop } from "../utils/misc/browserDetection";
+import { runningInChromeDesktop, runningInFirefoxDesktop } from "../utils/misc/browserDetection";
 import { checkExtensionInstalled } from "../utils/misc/extensionCommunication";
 import ShowLinkRecommendationsIfNoArticles from "./ShowLinkRecommendationsIfNoArticles";
 
@@ -25,8 +25,8 @@ export default function NewArticles({ api }) {
   useEffect(() => {
     setDisplayedExtensionPopup(LocalStorage.displayedExtensionPopup());
     console.log("Running in chrome desktop: " + runningInChromeDesktop())
-    console.log("Localstorage displayed extension: "+ LocalStorage.displayedExtensionPopup())
-    if (runningInChromeDesktop() && Feature.extension_experiment1() && !displayedExtensionPopup) {
+    console.log("Running in firefox desktop: " + runningInFirefoxDesktop())
+    if ((runningInChromeDesktop() || runningInFirefoxDesktop) && Feature.extension_experiment1() && !displayedExtensionPopup) {
       checkExtensionInstalled(setHasExtension);
     }
   }, []);

--- a/src/articles/Reminder.js
+++ b/src/articles/Reminder.js
@@ -1,6 +1,6 @@
 import { ExtensionReminder } from "./Reminder.sc";
 import Feature from "../features/Feature";
-import { runningInChromeDesktop } from "../utils/misc/browserDetection";
+import { runningInChromeDesktop, runningInFirefoxDesktop  } from "../utils/misc/browserDetection";
 
 export default function Reminder({ hasExtension }) {
   console.log("Running in Chrome Desktop: " + runningInChromeDesktop())
@@ -20,17 +20,36 @@ export default function Reminder({ hasExtension }) {
       </ExtensionReminder>
     );
   }
-  if (!runningInChromeDesktop() && Feature.extension_experiment1()) {
+  if (!hasExtension && runningInFirefoxDesktop() && Feature.extension_experiment1()) {
+    return (
+      <ExtensionReminder>
+        To read articles with the help of Zeeguu you need to read them from the
+        Firefox extension or by adding the texts to "My Texts" through the "Save
+        article to Zeeguu.org" button from within the extension.
+        <a
+          href=""
+          rel="noopener noreferrer"
+        > Install the extension from the Firefox Add-ons library.
+        </a>
+      </ExtensionReminder>
+    );
+  }
+  if (!runningInChromeDesktop()  && !runningInFirefoxDesktop() &&  Feature.extension_experiment1()) {
     return (
       <ExtensionReminder>
         To read articles with the help of Zeeguu you should read them from the
-        Chrome extension. Thus you must use a Chrome browser. From within the
-        extension you can then add texts to "My Texts" through the "Save
-        article to Zeeguu.org" button.
+        Chrome or Firefox extension. Thus you must use a Chrome or Firefox
+        browser. From within the extension you can then add texts to "My Texts"
+        through the "Save article to Zeeguu.org" button. Install the extension in the 
         <a
           href="https://chrome.google.com/webstore/detail/zeeguu/ckncjmaednfephhbpeookmknhmjjodcd"
           rel="noopener noreferrer"
-        > Install the extension in the Chrome Web Store.
+        > Chrome Web Store 
+        </a> or install it in the 
+        <a
+          href=""
+          rel="noopener noreferrer"
+        > Firefox Browser Add-ons library.
         </a>
       </ExtensionReminder>
     );

--- a/src/components/ExtensionMessage.js
+++ b/src/components/ExtensionMessage.js
@@ -34,7 +34,14 @@ export default function ExtensionMessage({open, hasExtension, displayedExtension
               href="https://chrome.google.com/webstore/detail/zeeguu/ckncjmaednfephhbpeookmknhmjjodcd"
               rel="noopener noreferrer"
             >
-              {strings.extensionInstall}
+              {strings.extensionChromeInstall}
+            </a>
+            <br /> <br />
+            <a
+              href=""
+              rel="noopener noreferrer"
+            >
+            {strings.extensionFirefoxInstall}
             </a>
           </p>
         </s.MyBox>

--- a/src/components/ExtensionMessage.sc.js
+++ b/src/components/ExtensionMessage.sc.js
@@ -20,6 +20,10 @@ const MyBox = styled(Box)`
 
   h1 {
     font-size: 1.3em;
+    text-align: center;
+  }
+  a{
+    text-align: center;
   }
 `;
 

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -286,7 +286,7 @@ let strings = new LocalizedStrings(
 
       //EmptyArticles
       noArticles:
-        'We have not collected articles in the language you want to study. To read articles with the help of Zeeguu you can instead browse the web and read articles with the Chrome extension. You can also add articles to "My Texts" through the "Save article to Zeeguu.org" button from within the extension.',
+        'We have not collected articles in the language you want to study. To read articles with the help of Zeeguu you can instead browse the web and read articles with the Chrome or Firefox extension. You can also add articles to "My Texts" through the "Save article to Zeeguu.org" button from within the extension.',
       newssites: "Examples of some of the most popular news sites are:",
 
       //ExerciseType
@@ -524,7 +524,7 @@ let strings = new LocalizedStrings(
 
       // New user created
       userCreated: "Welcome to Zeeguu",
-      installExtension: " Time to install the Zeeguu Reader Chrome extension",
+      installExtension: " Time to install the Zeeguu Reader Chrome or Firefox extension",
       extensionDescription:
         "Here on zeeguu.org you can see your words, find article recommendation links, do exercises, see statistics, etc. You can also read, but only articles that were shared with you by your teacher, or articles that you have saved from the extension.",
       extensionFunctionality:
@@ -541,14 +541,15 @@ let strings = new LocalizedStrings(
       congratulations: "Extension is installed!",
 
       //ExtensionMessage
-      extensionHeadline: "Install the Zeeguu Chrome Extension to read articles",
+      extensionHeadline: "Install the Zeeguu Chrome or Firefox Extension to read articles",
       extensionAllow:
         " The extension allows you to enrich your vocabulary in a foreign language while browsing the web and reading articles that are interesting to you. These could be articles on news sites, blogs, or encyclopedias like Wikipedia.",
       extensionToRead:
-        'To read articles with the help of Zeeguu you need to read them from the Chrome Extension or by adding the texts to "My Texts" through the "Save article to Zeeguu.org" button from within the extension.',
+        'To read articles with the help of Zeeguu you need to read them from the Chrome or Firefox Extension or by adding the texts to "My Texts" through the "Save article to Zeeguu.org" button from within the extension.',
       extensionReadability:
         "For better readability, the extension removes all excess clutter, like adverts, buttons, and videos.",
-      extensionInstall: "Install it in the Chrome Web Store",
+      extensionChromeInstall: "Install it in the Chrome Web Store",
+      extensionFirefoxInstall: "Install it in the Firefox Add-ons library",
 
       //TooltipedButtons
       viewAsStudent: "View as Student",

--- a/src/pages/InstallExtension.js
+++ b/src/pages/InstallExtension.js
@@ -14,19 +14,26 @@ export default function InstallExtension() {
           <p>{strings.extensionDescription}</p>
           <p>{strings.extensionFunctionality}</p>
           <ul>
-            <li><p>{strings.extensionAdvantage1}</p></li>
-            <li> <p>{strings.extensionAdvantage2}</p></li>
-            <li> <p>{strings.extensionAdvantage3}</p></li>
+            <li>
+              <p>{strings.extensionAdvantage1}</p>
+            </li>
+            <li>
+              <p>{strings.extensionAdvantage2}</p>
+            </li>
+            <li>
+              <p>{strings.extensionAdvantage3}</p>
+            </li>
           </ul>
           <s.LinkContainer>
             <s.OrangeButton>
               <a href="https://chrome.google.com/webstore/detail/the-zeeguu-reader/ckncjmaednfephhbpeookmknhmjjodcd">
-                Install "The Zeeguu Reader"
+                Install for Chrome
               </a>
             </s.OrangeButton>
-            <a href="/articles">
-                Don't want the extension? Go to articles.
-              </a>
+            <s.OrangeButton>
+              <a href="">Install for Firefox</a>
+            </s.OrangeButton>
+            <a href="/articles">Don't want the extension? Go to articles.</a>
           </s.LinkContainer>
         </s.InstallExtensionWrapper>
       </ExtensionContainer>

--- a/src/utils/misc/browserDetection.js
+++ b/src/utils/misc/browserDetection.js
@@ -7,6 +7,15 @@ function runningInChromeDesktop() {
   }
 }
 
+function runningInFirefoxDesktop() {
+  let userAgent = navigator.userAgent;
+  if (userAgent.match(/firefox/i) && isMobile() === false) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 // cf: https://stackoverflow.com/questions/3514784/what-is-the-best-way-to-detect-a-mobile-device
 function isMobile() {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobi|Android/i.test(
@@ -14,4 +23,4 @@ function isMobile() {
   );
 }
 
-export { isMobile, runningInChromeDesktop };
+export { isMobile, runningInChromeDesktop,runningInFirefoxDesktop };

--- a/src/utils/misc/extensionCommunication.js
+++ b/src/utils/misc/extensionCommunication.js
@@ -1,32 +1,46 @@
 /*global chrome*/
 // (this will let our linter know we are accessing Chrome browser methods)
-import { runningInChromeDesktop } from "./browserDetection";
+import {
+  runningInChromeDesktop,
+  runningInFirefoxDesktop,
+} from "./browserDetection";
 
 function checkExtensionInstalled(setHasExtension) {
-  if(runningInChromeDesktop()){
-  if (chrome.runtime) {
-    chrome.runtime.sendMessage(
-      process.env.REACT_APP_EXTENSION_ID,
-      "You are on Zeeguu.org!",
-      function (response) {
-        if (chrome.runtime.lastError) {
-          console.log(chrome.runtime.lastError);
-        }
-        if (response) {
-          console.log("Extension installed!");
-          setHasExtension(true);
-        } else {
-          setHasExtension(false);
-          console.log("Extension not installed!")
+  if (runningInChromeDesktop()) {
+    if (chrome.runtime) {
+      chrome.runtime.sendMessage(
+        process.env.REACT_APP_EXTENSION_ID, "You are on Zeeguu.org!", function (response) {
+          if (chrome.runtime.lastError) {
+            console.log(chrome.runtime.lastError);
           }
+          if (response) {
+            console.log("Extension installed!");
+            setHasExtension(true);
+          } else {
+            setHasExtension(false);
+          }
+        }
+      );
+    } else {
+      setHasExtension(false);
+    }
+  }
+  if (runningInFirefoxDesktop()) {
+    let firefoxExtension;
+    window.addEventListener("message", function (event) {
+      if (
+        event.source == window &&
+        event.data.direction === "from-content-script"
+      ) {
+        setHasExtension(true);
+        firefoxExtension = true;
+        console.log("Extension installed!");
       }
-    );
+      if (!firefoxExtension) {
+        setHasExtension(false);
+      }
+    });
   } else {
-    console.log("Extension not installed!")
-    setHasExtension(false);
-  }}
-  else {
-    console.log("Extension not installed!")
     setHasExtension(false);
   }
 }


### PR DESCRIPTION
Mostly these are changes made to strings - because we now have two extensions. We also need to check if they use Firefox - and because Manifest V3 do not support the same functions, then we also have to detect if they have an extension through a content script. So this is different from Chrome.

Though this should not be deployed before people can download the Firefox extension. So do not merge just yet. We also need to add the correct links for the Firefox extension.