### PR TITLE
Fixed error with 40 extension checks

### DIFF
--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -2,21 +2,14 @@ import { Link } from "react-router-dom";
 import moment from "moment";
 import * as s from "./ArticlePreview.sc";
 import Feature from "../features/Feature";
-import { useState, useEffect } from "react";
-import { checkExtensionInstalled } from "../utils/misc/extensionCommunication";
 import {runningInChromeDesktop} from "../utils/misc/browserDetection";
 
 export default function ArticleOverview({
   article,
   dontShowPublishingTime,
   dontShowImage,
+  hasExtension
 }) {
-  const [hasExtension, setHasExtension] = useState(false);
-
-  useEffect(() => {
-      checkExtensionInstalled(setHasExtension);
-  }, []);
-
   let topics = article.topics.split(" ").filter((each) => each !== "");
   let difficulty = Math.round(article.metrics.difficulty * 100) / 10;
 

--- a/src/articles/FindArticles.js
+++ b/src/articles/FindArticles.js
@@ -84,7 +84,7 @@ export default function NewArticles({ api }) {
       />
       <Reminder hasExtension={hasExtension}></Reminder>
       {articleList.map((each) => (
-        <ArticlePreview key={each.id} article={each} api={api} />
+        <ArticlePreview key={each.id} article={each} api={api} hasExtension={hasExtension}/>
       ))}
       <ShowLinkRecommendationsIfNoArticles articleList={articleList}></ShowLinkRecommendationsIfNoArticles>
     </>


### PR DESCRIPTION
Fixed this error: https://github.com/zeeguu-ecosystem/zeeguu-react/issues/196

We ran checkExtensionInstalled for every articlePreview loaded on the article page. So, around 40 times, if there were 40 articles. It had an easy fix :) 

We need it to open the article on the news site instead of zeeguu, if the extension is installed 