### PR TITLE
Video guide and logging /extension_installed 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -119,7 +119,7 @@ function App() {
 
             <Route
               path="/extension_installed"
-              render={() => <ExtensionInstalled />}
+              render={() => <ExtensionInstalled api={api}/>}
             />
 
             <Route

--- a/src/api/activityLogging.js
+++ b/src/api/activityLogging.js
@@ -4,6 +4,7 @@ import qs from "qs";
 // Reader Opening Actions
 Zeeguu_API.prototype.OPEN_ARTICLE = "OPEN ARTICLE";
 Zeeguu_API.prototype.ARTICLE_FOCUSED = "ARTICLE FOCUSED";
+Zeeguu_API.prototype.OPEN_EXTENSION_INSTALLED = "OPEN EXTENSION INSTALLED";
 
 // Reader Interaction Actions
 Zeeguu_API.prototype.TRANSLATE_TEXT = "TRANSLATE TEXT";

--- a/src/articles/Reminder.js
+++ b/src/articles/Reminder.js
@@ -23,12 +23,12 @@ export default function Reminder({ hasExtension }) {
   if (hasExtension && runningInChromeDesktop() && Feature.extension_experiment1()) {
     return(
     <ExtensionReminder>
-      To learn how to use the Zeeguu Reader Chrome extension, 
+      Learn how to use the Zeeguu Reader Chrome extension by watching
       <a
           href="https://vimeo.com/715531198"
           rel="noopener noreferrer"
           target="_blank"
-        > watch this video.
+        > this video.
         </a>
     </ExtensionReminder>
     )

--- a/src/articles/Reminder.js
+++ b/src/articles/Reminder.js
@@ -5,7 +5,7 @@ import { runningInChromeDesktop } from "../utils/misc/browserDetection";
 export default function Reminder({ hasExtension }) {
   console.log("Running in Chrome Desktop: " + runningInChromeDesktop())
   console.log("Feature experiment 1: " + Feature.extension_experiment1())
-  
+
   if (!hasExtension && runningInChromeDesktop() && Feature.extension_experiment1()) {
     return (
       <ExtensionReminder>
@@ -19,6 +19,19 @@ export default function Reminder({ hasExtension }) {
         </a>
       </ExtensionReminder>
     );
+  }
+  if (hasExtension && runningInChromeDesktop() && Feature.extension_experiment1()) {
+    return(
+    <ExtensionReminder>
+      To learn how to use the Zeeguu Reader Chrome extension, 
+      <a
+          href="https://vimeo.com/715531198"
+          rel="noopener noreferrer"
+          target="_blank"
+        > watch this video.
+        </a>
+    </ExtensionReminder>
+    )
   }
   if (!runningInChromeDesktop() && Feature.extension_experiment1()) {
     return (

--- a/src/pages/ExtensionInstalled.js
+++ b/src/pages/ExtensionInstalled.js
@@ -9,7 +9,7 @@ export default function ExtensionInstalled({ api }) {
   useEffect(() => {
     api.logUserActivity(api.OPEN_EXTENSION_INSTALLED);
   }, []);
-  
+
   return (
     <s.PageBackground>
       <z.LogoOnTop />
@@ -18,7 +18,7 @@ export default function ExtensionInstalled({ api }) {
           <h1>{strings.congratulations}</h1>
           <h4>{strings.pinExtension}</h4>
           <s.VideoLink>Learn how it works by watching
-          <a href="https://vimeo.com/715531198" target="_blank" rel="noreferrer"> this video</a>
+            <a href="https://vimeo.com/715531198" target="_blank" rel="noreferrer"> this video</a>
           </s.VideoLink>
           <img
             src={"https://zeeguu.org/static/images/zeeguuExtension.gif"}

--- a/src/pages/ExtensionInstalled.js
+++ b/src/pages/ExtensionInstalled.js
@@ -9,7 +9,7 @@ export default function ExtensionInstalled({ api }) {
   useEffect(() => {
     api.logUserActivity(api.OPEN_EXTENSION_INSTALLED);
   }, []);
-
+  
   return (
     <s.PageBackground>
       <z.LogoOnTop />
@@ -17,6 +17,9 @@ export default function ExtensionInstalled({ api }) {
         <s.ExtensionInstalledWrapper>
           <h1>{strings.congratulations}</h1>
           <h4>{strings.pinExtension}</h4>
+          <s.VideoLink>Learn how it works by watching
+          <a href="https://vimeo.com/715531198" target="_blank" rel="noreferrer"> this video</a>
+          </s.VideoLink>
           <img
             src={"https://zeeguu.org/static/images/zeeguuExtension.gif"}
             alt="How to pin Chrome Extension to Chrome Toolbar gif"

--- a/src/pages/ExtensionInstalled.js
+++ b/src/pages/ExtensionInstalled.js
@@ -2,8 +2,14 @@ import * as s from "./ExtensionInstalled.sc";
 import { getUserSession } from "../utils/cookies/userInfo";
 import * as z from "../components/FormPage.sc";
 import strings from "../i18n/definitions";
+import { useEffect } from "react";
 
-export default function ExtensionInstalled() {
+export default function ExtensionInstalled({ api }) {
+
+  useEffect(() => {
+    api.logUserActivity(api.OPEN_EXTENSION_INSTALLED);
+  }, []);
+
   return (
     <s.PageBackground>
       <z.LogoOnTop />

--- a/src/pages/ExtensionInstalled.sc.js
+++ b/src/pages/ExtensionInstalled.sc.js
@@ -65,10 +65,16 @@ let PageBackground = styled.div`
   background: ${zeeguuVeryLightOrange};
 `;
 
+let VideoLink = styled.p`
+  margin: 0em;
+  padding-bottom: 1em;
+`
+
 export {
   ExtensionInstalledWrapper,
   ExtensionContainer,
   LinkContainer,
   OrangeButton,
   PageBackground,
+  VideoLink
 };


### PR DESCRIPTION
I have inserted a link to the video on the extension installed page, and on the Texts page. It opens the video in vimeo in another tab. We’ve considered making a separate page on zeeguu for the video, so that the users are not sent to a different website, but that would also take more time to get ready - what do you think? 

![Extension installed](https://user-images.githubusercontent.com/90048883/171198038-7e9d6d31-e34b-42e5-9263-04e5f2031052.png)

![Texts](https://user-images.githubusercontent.com/90048883/171198088-a798412d-fcbf-45f5-a83c-09be1bd74398.png)
