### PR TITLE
Fix firefox reminder error

### DIFF
--- a/src/articles/Reminder.js
+++ b/src/articles/Reminder.js
@@ -70,8 +70,7 @@ export default function Reminder({ hasExtension }) {
         </a>
       </ExtensionReminder>
     );
-  } else {
+  }} else {
     return null;
   }
-}
 }


### PR DESCRIPTION
I saw that the Firefox reminder was still not working correctly after we merged the cross-browser branch into development. After a looong struggle ... I moved one closing bracket ...

It seems to work now. Will you merge and deploy? I can't fully check till after it is live on zeeguu.org. It works when I test on Localhost though :)